### PR TITLE
Custom server/host arguments

### DIFF
--- a/detox-server/package.json
+++ b/detox-server/package.json
@@ -24,6 +24,7 @@
   "author": "Tal Kol <talkol@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "commander": "^2.9.0",
     "lodash": "^4.13.1",
     "npmlog": "^4.0.2",
     "ws": "^1.1.0"

--- a/detox-server/src/DetoxServer.js
+++ b/detox-server/src/DetoxServer.js
@@ -7,11 +7,11 @@ log.heading = 'detox-server';
 log.loglevel = 'wss';
 
 class DetoxServer {
-  constructor(port) {
-    this.wss = new WebSocketServer({port: port});
+  constructor(port, host) {
+    this.wss = new WebSocketServer({port: port, host: host});
     this.sessions = {};
 
-    log.log('info', `${now()}:`, `server listening on localhost:${this.wss.options.port}...`);
+    log.log('info', `${now()}:`, `server listening on ${this.wss.options.host}:${this.wss.options.port}...`);
     this._setup();
   }
 

--- a/detox-server/src/cli.js
+++ b/detox-server/src/cli.js
@@ -1,8 +1,16 @@
 #! /usr/bin/env node
 const log = require('npmlog');
 const DetoxServer = require('./DetoxServer');
+const program = require('commander');
+
+program
+  .option('-s, --server [host]',
+    `The IP to bind detox-server. Defaults to localhost`, 'localhost')
+  .option('-p, --port [value]',
+    'The port to bind detox-server. Defaults to 8099', '8099')
+  .parse(process.argv);
 
 log.addLevel('wss', 999, {fg: 'blue', bg: 'black'}, 'wss');
 log.level = 'wss';
 
-const detoxServer = new DetoxServer(8099);
+const detoxServer = new DetoxServer(program.port, program.server);

--- a/detox/local-cli/detox-run-server.js
+++ b/detox/local-cli/detox-run-server.js
@@ -5,11 +5,20 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-program.parse(process.argv);
+program
+  .option('-s, --server [host]',
+    `The IP to bind detox-server`)
+  .option('-p, --port [value]',
+    'The port to bind detox-server')
+  .parse(process.argv);
+
+const server = program.server ? `--server ${program.server}` : '';
+const port = program.port ? `--port ${program.port}` : '';
+const arguments = `${server} ${port}`;
 
 if (fs.existsSync(path.join(process.cwd(), 'node_modules/.bin/detox-server'))) {
-  cp.execSync('node_modules/.bin/detox-server', {stdio: 'inherit'});
+  cp.execSync(`node_modules/.bin/detox-server ${arguments}`, {stdio: 'inherit'});
 } else {
-  cp.execSync('node_modules/detox/node_modules/.bin/detox-server', {stdio: 'inherit'});
+  cp.execSync(`node_modules/detox/node_modules/.bin/detox-server ${arguments}`, {stdio: 'inherit'});
 }
 

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -56,7 +56,8 @@ class Detox {
     const [sessionConfig, shouldStartServer] = await this._chooseSession(deviceConfig);
 
     if (shouldStartServer) {
-      this.server = new DetoxServer(new URL(sessionConfig.server).port);
+      const server = new URL(sessionConfig.server);
+      this.server = new DetoxServer(server.port, server.hostname);
     }
 
     this.client = new Client(sessionConfig);

--- a/detox/src/Detox.js
+++ b/detox/src/Detox.js
@@ -56,8 +56,8 @@ class Detox {
     const [sessionConfig, shouldStartServer] = await this._chooseSession(deviceConfig);
 
     if (shouldStartServer) {
-      const server = new URL(sessionConfig.server);
-      this.server = new DetoxServer(server.port, server.hostname);
+      const hostConfig = new URL(sessionConfig.host);
+      this.server = new DetoxServer(hostConfig.port, hostConfig.hostname);
     }
 
     this.client = new Client(sessionConfig);
@@ -108,7 +108,7 @@ class Detox {
 
   async _chooseSession(deviceConfig) {
     let session = deviceConfig.session;
-    let shouldStartServer = false;
+    let shouldStartServer = deviceConfig.session.shouldStartServer;
 
     if (!session) {
       session = this.userConfig.session;


### PR DESCRIPTION
Enable the use of custom server options to be passed to `detox-server`, so we can bind its IP address to `0.0.0.0`.

Example of the new configuration (on `package.json`):
```json
"detox": {
  "configurations": {
    "android.emu": {
      "binaryPath": "android/sample/build/outputs/apk/sample-appiumTest-release.apk",
      "build": "./android/scripts/build-detox.sh",
      "type": "android.attached",
      "name": "Nexus_5X_API_25",
      "session": {
        "shouldStartServer": "true",
        "host": "ws://0.0.0.0:9999",
        "server": "ws://172.19.193.234:9999",
        "sessionId": "123456-123456"
      }
    }
  }
}
```