### PR TITLE
Remove postinstall script

### DIFF
--- a/detox/package.json
+++ b/detox/package.json
@@ -25,8 +25,7 @@
     "test": "npm run unit",
     "posttest": "cp coverage/lcov.info coverage/unit.lcov",
     "unit:watch": "jest --watch",
-    "prepublish": "npm run build",
-    "postinstall": "node scripts/postinstall.js"
+    "prepublish": "npm run build"
   },
   "devDependencies": {
     "eslint": "^4.11.0",


### PR DESCRIPTION
After updating XCode 12, we are having this error:

```
npm ERR! errno 1
npm ERR! detox@12.10.0 postinstall: `node scripts/postinstall.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the detox@12.10.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

```

10.12
```
if (process.platform === "darwin") {
    require("child_process").execFileSync(`${__dirname}/build_framework.ios.sh`, {
        stdio: "inherit"
    });
}
```

18.2.2
(current master of Detox)
```
if (process.platform === "darwin" && !process.env.DETOX_DISABLE_POSTINSTALL) {
	require("child_process").execFileSync(`${__dirname}/build_framework.ios.sh`, {
		stdio: "inherit"
	});
}
```